### PR TITLE
The 'app' parameter must be required only for `synth` goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # AWS CDK Maven Plugin
 
 The AWS CDK Maven plugin produces and deploys CloudFormation templates based on your cloud infrastructure defined by 
-means of [CDK](https://aws.amazon.com/cdk/). The goal of the project is to improve the experience of Java developers 
-while working with CDK by eliminating the need for installing [Node.js](https://nodejs.org/en/download) and interacting 
-with the CDK application by means of [CDK Toolkit](https://docs.aws.amazon.com/cdk/latest/guide/tools.html).
+means of [CDK][1]. The goal of the project is to improve the experience of Java developers while working with CDK by 
+eliminating the need for installing [Node.js][2] and interacting with the CDK application by means of [CDK Toolkit][3].
 
 ## Prerequisites
 
@@ -24,16 +23,20 @@ depending on the platform).
 
 The plugin provides three goals:
 
-* `synth`: Synthesizes [CloudFormation](https://aws.amazon.com/cloudformation/) templates from the stacks defined in your
-CDK application.
-* `bootstrap`: Deploys required toolkit stacks into an AWS.
-* `deploy`: Deploys the cloud resources defined in the synthesized templates to AWS.
+* `synth`: Synthesizes [CloudFormation][4] templates based on the resources defined in your CDK application.
+* `bootstrap`: Deploys toolkit stacks required by the CDK application to an AWS.
+* `deploy`: Deploys the CDK application to an AWS (based on the synthesized resources)
 
-All three goals require the parameter `<app>` to be specified, which is a full class name of the CDK application class 
-defining the cloud infrastructure. The application class must either extend `software.amazon.awscdk.core.App` or define 
-a `main` method which is supposed to create an instance of `App`, define cloud 
-[constructs](https://docs.aws.amazon.com/cdk/latest/guide/constructs.html) and call `App#synth()` method in order to 
-produce a cloud assembly with CloudFormation templates.
+### Synthesis
+
+During the execution of `synth` goal, a cloud assembly is synthesized into a directory (`target/cdk.out` by default). 
+The cloud assembly includes CloudFormation templates, AWS Lambda bundles, file and Docker image assets, and other 
+deployment artifacts.
+
+The only mandatory parameter required by the goal is `<app>`, which is a full class name of the CDK app class defining 
+the cloud infrastructure. The application class must either extend `software.amazon.awscdk.core.App` or define a 
+`main` method which is supposed to create an instance of `App`, define cloud [constructs][5] and call `App#synth()` 
+method in order to produce a cloud assembly with CloudFormation templates.
 
 Extending `App` class:
 ```java
@@ -63,3 +66,26 @@ public class MyApp {
     
 }
 ```
+
+### Bootstrapping
+
+Some CDK applications may require a "toolkit stack" that includes the resources required for the application operation. 
+For example, the toolkit stack may include S3 bucket used to store templates and assets for the deployment.
+
+The plugin is able to detect if a stack requires a toolkit stack and if it does, the plugin will automatically deploy it 
+(or update if needed) during the execution of `bootstrap` goal (provided that the required toolkit stack version wasn't 
+already deployed). You may also choose to omit `bootstrap` goal if you don't want to rely on the plugin and control this 
+process by yourself or just want to make sure that the toolkit stack is not created by a mistake. If you choose to omit 
+`bootstrap` goal, you will need to install the toolkit stack the first time you deploy an AWS CDK application into an 
+environment (account/region) by running `cdk bootstrap` command (please refer to [AWS CDK Toolkit][3] for the details).
+
+### Deployment
+
+To deploy the synthesized application into an AWS, add `deploy` goal to the execution (`deploy` and `bootstrap` goals are
+attached to the `deploy` Maven phase).
+
+[1]: https://aws.amazon.com/cdk/
+[2]: https://nodejs.org/en/download
+[3]: https://docs.aws.amazon.com/cdk/latest/guide/tools.html#cli
+[4]: https://aws.amazon.com/cloudformation/
+[5]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/AbstractCdkMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/AbstractCdkMojo.java
@@ -39,15 +39,6 @@ public abstract class AbstractCdkMojo extends AbstractMojo {
             .registerModule(new JSR353Module());
 
     /**
-     * The name of the application class defining your cloud infrastructure. The application class must either extend
-     * {@link software.amazon.awscdk.core.App} or define a main method which would create an instance of {@code App},
-     * define the constructs associated with it and call {@link software.amazon.awscdk.core.App#synth()} method in order
-     * to produce a cloud assembly with CloudFormation templates.
-     */
-    @Parameter(required = true)
-    private String app;
-
-    /**
      * A profile that will be used while looking for credentials and region.
      */
     @Parameter
@@ -62,7 +53,7 @@ public abstract class AbstractCdkMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
         try {
-            execute(app, cloudAssemblyDirectory.toPath(), createEnvironmentResolver());
+            execute(cloudAssemblyDirectory.toPath(), createEnvironmentResolver());
         } catch (CdkPluginException e) {
             throw new MojoExecutionException(e.getMessage(), e.getCause());
         } catch (Exception e) {
@@ -70,7 +61,7 @@ public abstract class AbstractCdkMojo extends AbstractMojo {
         }
     }
 
-    public abstract void execute(String app, Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver);
+    public abstract void execute(Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver);
 
     /**
      * Creates an {@code EnvironmentResolved} based on the default region and credentials.

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/BootstrapMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/BootstrapMojo.java
@@ -40,7 +40,7 @@ public class BootstrapMojo extends AbstractCdkMojo {
     private ToolkitConfiguration toolkit;
 
     @Override
-    public void execute(String app, Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
+    public void execute(Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
         if (!Files.exists(cloudAssemblyDirectory)) {
             throw new CdkPluginException("The cloud assembly directory " + cloudAssemblyDirectory + " doesn't exist. " +
                     "Did you forget to add 'synth' goal to the execution?");

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DeployMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DeployMojo.java
@@ -29,7 +29,7 @@ public class DeployMojo extends AbstractCdkMojo {
     private ToolkitConfiguration toolkit;
 
     @Override
-    public void execute(String app, Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
+    public void execute(Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
         if (!Files.exists(cloudAssemblyDirectory)) {
             throw new CdkPluginException("The cloud assembly directory " + cloudAssemblyDirectory + " doesn't exist. " +
                     "Did you forget to add 'synth' goal to the execution?");

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/SynthMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/SynthMojo.java
@@ -114,11 +114,20 @@ public class SynthMojo extends AbstractCdkMojo implements ContextEnabled {
     @Parameter(defaultValue = "${settings.localRepository}", readonly = true)
     private File localRepositoryDirectory;
 
+    /**
+     * The name of the application class defining your cloud infrastructure. The application class must either extend
+     * {@link software.amazon.awscdk.core.App} or define a main method which would create an instance of {@code App},
+     * define the constructs associated with it and call {@link software.amazon.awscdk.core.App#synth()} method in order
+     * to produce a cloud assembly with CloudFormation templates.
+     */
+    @Parameter(required = true)
+    private String app;
+
     private ProcessRunner processRunner;
     private Map<String, ContextProvider> contextProviders;
 
     @Override
-    public void execute(String app, Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
+    public void execute(Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
         this.processRunner = new DefaultProcessRunner(project.getBasedir());
         this.contextProviders = initContextProviders(environmentResolver);
         synthesize(app, cloudAssemblyDirectory, environmentResolver);


### PR DESCRIPTION
Currently, the `app` parameter can be defined for all three goals even though it's actually used only during synthesis in `SynthMojo`. The `BootstrapMojo` and `DeployMojo` don't use it and must not define it (currently, the parameter is defined in `AbstractCdkMojo` which both extend).

The pull request fixes it and moves the `app` parameter definition to `SynthMojo`.