### PR TITLE
Replace 'toolkit.stackName' configuration parameter with 'toolkitStackName'

### DIFF
--- a/aws-cdk-maven-plugin/src/it/synth-deploy-basic/pom.xml
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-basic/pom.xml
@@ -50,9 +50,7 @@
                         </goals>
                         <configuration>
                             <app>io.linguarobot.aws.cdk.maven.it.DeployBasicTestApp</app>
-                            <toolkit>
-                                <stackName>basic-it-cdk-toolkit</stackName>
-                            </toolkit>
+                            <toolkitStackName>basic-it-cdk-toolkit</toolkitStackName>
                         </configuration>
                     </execution>
                 </executions>

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-ecs-service/cdk-stack/pom.xml
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-ecs-service/cdk-stack/pom.xml
@@ -68,9 +68,7 @@
                         </goals>
                         <configuration>
                             <app>io.linguarobot.aws.cdk.maven.it.EcsServiceTestApp</app>
-                            <toolkit>
-                                <stackName>ecs-service-it-cdk-toolkit</stackName>
-                            </toolkit>
+                            <toolkitStackName>ecs-service-it-cdk-toolkit</toolkitStackName>
                         </configuration>
                     </execution>
                 </executions>

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-lambda-function/cdk-stack/pom.xml
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-lambda-function/cdk-stack/pom.xml
@@ -64,9 +64,7 @@
                         </goals>
                         <configuration>
                             <app>io.linguarobot.aws.cdk.maven.it.DeployLambdaFunctionTestApp</app>
-                            <toolkit>
-                                <stackName>lambda-function-it-cdk-toolkit</stackName>
-                            </toolkit>
+                            <toolkitStackName>lambda-function-it-cdk-toolkit</toolkitStackName>
                         </configuration>
                     </execution>
                 </executions>

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DeployMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DeployMojo.java
@@ -23,10 +23,10 @@ public class DeployMojo extends AbstractCdkMojo {
     private MavenProject project;
 
     /**
-     * Toolkit stack configuration.
+     * The name of the CDK toolkit stack
      */
-    @Parameter(defaultValue = "${toolkit}")
-    private ToolkitConfiguration toolkit;
+    @Parameter(defaultValue = "CDKToolkit")
+    private String toolkitStackName;
 
     @Override
     public void execute(Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
@@ -43,8 +43,9 @@ public class DeployMojo extends AbstractCdkMojo {
             ResolvedEnvironment resolvedEnvironment = environmentResolver.resolve(environment);
             DockerImageAssetPublisher dockerImagePublisher = new DockerImageAssetPublisher(resolvedEnvironment, processRunner);
             FileAssetPublisher filePublisher = new FileAssetPublisher(resolvedEnvironment);
-            StackDeployer stackDeployer = new StackDeployer(cloudAssemblyDirectory, resolvedEnvironment, toolkit,
-                    filePublisher, dockerImagePublisher);
+            ToolkitConfiguration toolkitConfiguration = new ToolkitConfiguration(toolkitStackName);
+            StackDeployer stackDeployer = new StackDeployer(cloudAssemblyDirectory, resolvedEnvironment,
+                    toolkitConfiguration, filePublisher, dockerImagePublisher);
             environmentStacks.forEach(stack -> {
                 if (!stack.getResources().isEmpty()) {
                     stackDeployer.deploy(stack);

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/ToolkitConfiguration.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/ToolkitConfiguration.java
@@ -5,13 +5,10 @@ package io.linguarobot.aws.cdk.maven;
  */
 public class ToolkitConfiguration {
 
-    /**
-     * The name of the toolkit stack.
-     */
-    private String stackName;
+    private final String stackName;
 
-    public ToolkitConfiguration() {
-        this.stackName = "CDKToolkit";
+    public ToolkitConfiguration(String stackName) {
+        this.stackName = stackName;
     }
 
     public String getStackName() {


### PR DESCRIPTION
Currently, the toolkit stack is configured using `ToolkitConfiguration` object parameter `toolkit` (containing a single field `stackName`). This approach doesn't look good in terms of plugin configuration experience. The toolkit stack name property is used in `bootstrap` and `deploy`, however, `bootstrap` goal is supposed to take other toolkit stack configuration parameters such as bucket name, etc. If we stick to the current approach, the `ToolkitConfiguration` object will have configurational parameters that are used in `BootstrapMojo` but ignored in `DeployMojo`. Besides it, it doesn't make sense to use a separate `ToolkitConfiguration` object as, most probably, all the parameters taken by `bootstrap` goal are related to the toolkit stack.