### PR TITLE
The error message is printed twice if synthesis fails

### DIFF
--- a/aws-cdk-maven-plugin-runtime/src/main/java/io/linguarobot/aws/cdk/maven/runtime/Synthesizer.java
+++ b/aws-cdk-maven-plugin-runtime/src/main/java/io/linguarobot/aws/cdk/maven/runtime/Synthesizer.java
@@ -22,7 +22,6 @@ public class Synthesizer {
         try {
             run(args[0], Arrays.copyOfRange(args, 1, args.length));
         } catch (Throwable e) {
-            System.err.print(e.toString());
             e.printStackTrace(System.err);
             System.exit(1);
         }


### PR DESCRIPTION
Currently, an error message is printed twice if an error happens during synthesis. The PR fixes it.