### PR TITLE
Suppress the logs related to downloading packages during integration tests

### DIFF
--- a/aws-cdk-maven-plugin/pom.xml
+++ b/aws-cdk-maven-plugin/pom.xml
@@ -168,6 +168,9 @@
                     <environmentVariables>
                         <AWS_REGION>us-east-1</AWS_REGION>
                     </environmentVariables>
+                    <mavenOpts>
+                        -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+                    </mavenOpts>
                     <goals>
                         <goal>clean</goal>
                         <goal>deploy</goal>


### PR DESCRIPTION
Set `org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn` in order to not log the information about downloading packages during integration tests.