### PR TITLE
Downgrade Maven API version and change its scope

### DIFF
--- a/aws-cdk-maven-plugin/pom.xml
+++ b/aws-cdk-maven-plugin/pom.xml
@@ -31,6 +31,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/node/UnixNodeInstaller.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/node/UnixNodeInstaller.java
@@ -4,7 +4,7 @@ import io.linguarobot.aws.cdk.maven.process.ProcessRunner;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.compress.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/node/WindowsNodeInstaller.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/node/WindowsNodeInstaller.java
@@ -1,7 +1,7 @@
 package io.linguarobot.aws.cdk.maven.node;
 
 import io.linguarobot.aws.cdk.maven.process.ProcessRunner;
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.compress.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.version>3.6.3</maven.version>
+        <maven.version>3.5.0</maven.version>
         <maven.tools.version>3.6.0</maven.tools.version>
         <aws.sdk.version>2.13.0</aws.sdk.version>
         <aws.cdk.version>1.41.0</aws.cdk.version>
@@ -99,7 +99,6 @@
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
                 <version>${maven.tools.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Fixes #20 

* The version of the `maven-core` and `maven-plugin-api` is downgraded to `3.5.0`. 
* The scope of `maven-core` is changed from `compile` to `provided`.