### PR TITLE
Add a parameter to control which stacks need to be deployed

### DIFF
--- a/aws-cdk-cloud-manifest/src/main/java/io/linguarobot/aws/cdk/Artifact.java
+++ b/aws-cdk-cloud-manifest/src/main/java/io/linguarobot/aws/cdk/Artifact.java
@@ -19,7 +19,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = StackArtifact.class, name = "aws:cloudformation:stack"),
         @JsonSubTypes.Type(value = TreeArtifact.class, name = "cdk:tree"),
         @JsonSubTypes.Type(value = AssetArtifact.class,name = "cdk:asset-manifest"),
-        @JsonSubTypes.Type(value = ArtifactMetadata.class, name = "none")
+        @JsonSubTypes.Type(value = Artifact.class, name = "none")
 })
 public class Artifact {
 

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-lambda-function/pom.xml
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-lambda-function/pom.xml
@@ -35,11 +35,6 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awscdk</groupId>
-                <artifactId>dynamodb</artifactId>
-                <version>${cdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awscdk</groupId>
                 <artifactId>apigateway</artifactId>
                 <version>${cdk.version}</version>
             </dependency>

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-lambda-function/verify.groovy
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-lambda-function/verify.groovy
@@ -1,9 +1,7 @@
 import io.linguarobot.aws.cdk.maven.Stacks
+import io.linguarobot.aws.cdk.maven.ToolkitStacks
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
-import software.amazon.awssdk.services.cloudformation.model.Stack
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
-import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.*
 
 import java.util.stream.Stream
 
@@ -20,7 +18,7 @@ try {
     assert toolkitStack?.stackStatus() == StackStatus.CREATE_COMPLETE
 
     def endpointUrl = Stacks.findOutput(stack, "Endpoint")
-            .map(output -> new URL(output.outputValue()))
+            .map{output -> new URL(output.outputValue())}
             .orElse(null)
     assert endpointUrl != null
 
@@ -30,48 +28,13 @@ try {
     assert connection.getInputStream().getText() == "SUCCESS"
 } finally {
     def stack = Stacks.findStack(cfnClient, STACK_NAME)
-            .map(s -> Stacks.deleteStack(cfnClient, s.stackName()))
+            .map{s -> Stacks.deleteStack(cfnClient, s.stackName())}
             .orElse(null)
     def toolkitStack = Stacks.findStack(cfnClient, TOOLKIT_STACK_NAME)
-            .map(s -> deleteToolkitStack(cfnClient, s))
+            .map{s -> ToolkitStacks.deleteToolkitStack(cfnClient, s)}
             .orElse(null)
 
     Stream.of(stack, toolkitStack)
         .filter(Objects::nonNull)
-        .forEach(s -> Stacks.awaitCompletion(cfnClient, s))
-}
-
-static Stack deleteToolkitStack(CloudFormationClient cfnClient, Stack toolkitStack) {
-    toolkitStack.outputs().stream()
-            .filter { output -> output.outputKey() == "BucketName" }
-            .map { output -> output.outputValue() }
-            .findAny()
-            .ifPresent { fileAssetBucketName -> emptyBucket(S3Client.create(), fileAssetBucketName) }
-
-    return Stacks.deleteStack(cfnClient, toolkitStack.stackName());
-}
-
-static def emptyBucket(S3Client client, String bucketName) {
-    ListObjectVersionsRequest listObjectVersionsRequest = ListObjectVersionsRequest.builder()
-            .bucket(bucketName)
-            .build()
-    def objectVersionsIterator = client.listObjectVersionsPaginator(listObjectVersionsRequest)
-            .versions()
-            .iterator()
-    while (objectVersionsIterator.hasNext()) {
-        List<ObjectIdentifier> objectIdentifiers = new ArrayList<>();
-        while (objectVersionsIterator.hasNext() && objectIdentifiers.size() < 1000) {
-            ObjectVersion objectVersion = objectVersionsIterator.next();
-            ObjectIdentifier objectIdentifier = ObjectIdentifier.builder()
-                    .key(objectVersion.key())
-                    .versionId(objectVersion.versionId())
-                    .build();
-            objectIdentifiers.add(objectIdentifier);
-        }
-        DeleteObjectsRequest deleteRequest = DeleteObjectsRequest.builder()
-                .bucket(bucketName)
-                .delete(Delete.builder().objects(objectIdentifiers).build())
-                .build()
-        client.deleteObjects(deleteRequest);
-    }
+        .forEach{s -> Stacks.awaitCompletion(cfnClient, s)}
 }

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/file-asset.txt
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/file-asset.txt
@@ -1,0 +1,1 @@
+File asset to trigger the deployment of the toolkit stack

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/pom.xml
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.linguarobot</groupId>
+    <artifactId>synth-deploy-stacks-parameter-it</artifactId>
+    <version>1.0.0</version>
+
+    <description>
+        Tests that only the stacks (and corresponding toolkit stacks) specified in the 'stacks' parameter are deployed
+    </description>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cdk.version>1.35.0</cdk.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>core</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>s3-assets</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>aws-cdk-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>synth</id>
+                        <goals>
+                            <goal>synth</goal>
+                        </goals>
+                        <configuration>
+                            <app>io.linguarobot.aws.cdk.maven.it.StacksParameterApp</app>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>deploy-dev</id>
+                        <goals>
+                            <goal>bootstrap</goal>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <stacks>
+                                <stack>stacks-parameter-test-stack-dev</stack>
+                            </stacks>
+                            <toolkitStackName>stacks-parameter-cdk-toolkit-dev</toolkitStackName>
+                            <parameters>
+                                <UserTableName>user_dev</UserTableName>
+                            </parameters>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>deploy-prod</id>
+                        <goals>
+                            <goal>bootstrap</goal>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <stacks>
+                                <stack>stacks-parameter-test-stack-prod</stack>
+                            </stacks>
+                            <toolkitStackName>stacks-parameter-cdk-toolkit-prod</toolkitStackName>
+                            <parameters>
+                                <UserTableName>user</UserTableName>
+                            </parameters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/src/main/java/io/linguarobot/aws/cdk/maven/it/StacksParameterApp.java
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/src/main/java/io/linguarobot/aws/cdk/maven/it/StacksParameterApp.java
@@ -1,0 +1,16 @@
+package io.linguarobot.aws.cdk.maven.it;
+
+import software.amazon.awscdk.core.App;
+
+
+public class StacksParameterApp {
+
+    public static void main(String[] args) {
+        App app = new App();
+        new StacksParametersTestStack(app, "stacks-parameter-test-stack-dev");
+        new StacksParametersTestStack(app, "stacks-parameter-test-stack-prod");
+        new StacksParametersTestStack(app, "stacks-parameter-test-stack-test");
+        app.synth();
+    }
+
+}

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/src/main/java/io/linguarobot/aws/cdk/maven/it/StacksParametersTestStack.java
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/src/main/java/io/linguarobot/aws/cdk/maven/it/StacksParametersTestStack.java
@@ -1,0 +1,38 @@
+package io.linguarobot.aws.cdk.maven.it;
+
+import software.amazon.awscdk.core.CfnParameter;
+import software.amazon.awscdk.core.Construct;
+import software.amazon.awscdk.core.RemovalPolicy;
+import software.amazon.awscdk.core.Stack;
+import software.amazon.awscdk.services.dynamodb.Attribute;
+import software.amazon.awscdk.services.dynamodb.AttributeType;
+import software.amazon.awscdk.services.dynamodb.BillingMode;
+import software.amazon.awscdk.services.dynamodb.Table;
+import software.amazon.awscdk.services.s3.assets.Asset;
+
+
+public class StacksParametersTestStack extends Stack {
+
+    public StacksParametersTestStack(final Construct scope, final String id) {
+        super(scope, id);
+
+        CfnParameter userTableName = CfnParameter.Builder.create(this, "UserTableName")
+                .description("The name of the user table")
+                .build();
+
+        // A file asset to trigger the deployment of the toolkit stack
+        Asset.Builder.create(this, "FileAsset")
+                .path("file-asset.txt")
+                .build();
+
+        Table.Builder.create(this, "UserTable")
+                .removalPolicy(RemovalPolicy.DESTROY)
+                .tableName(userTableName.getValueAsString())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .partitionKey(Attribute.builder()
+                        .name("id")
+                        .type(AttributeType.STRING)
+                        .build())
+                .build();
+    }
+}

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/verify.groovy
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/verify.groovy
@@ -1,0 +1,44 @@
+import io.linguarobot.aws.cdk.maven.Stacks
+import io.linguarobot.aws.cdk.maven.ToolkitStacks
+import software.amazon.awscdk.core.Stack
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient
+import software.amazon.awssdk.services.cloudformation.model.StackStatus
+
+import java.util.stream.Collectors
+import java.util.stream.Stream
+
+CloudFormationClient cfnClient = CloudFormationClient.create();
+
+try {
+    def devStack = Stacks.findStack(cfnClient, "stacks-parameter-test-stack-dev").orElse(null);
+    assert devStack?.stackStatus() == StackStatus.CREATE_COMPLETE
+    def devToolkitStack = Stacks.findStack(cfnClient, "stacks-parameter-cdk-toolkit-dev").orElse(null);
+    assert devToolkitStack?.stackStatus() == StackStatus.CREATE_COMPLETE
+
+    def testStack = Stacks.findStack(cfnClient, "stacks-parameter-test-stack-test").orElse(null);
+    assert testStack == null
+    def testToolkitStack = Stacks.findStack(cfnClient, "stacks-parameter-cdk-toolkit-test").orElse(null);
+    assert testToolkitStack == null
+
+    def prodStack = Stacks.findStack(cfnClient, "stacks-parameter-test-stack-prod").orElse(null);
+    assert prodStack?.stackStatus() == StackStatus.CREATE_COMPLETE
+    def prodToolkitStack = Stacks.findStack(cfnClient, "stacks-parameter-cdk-toolkit-prod").orElse(null);
+    assert prodToolkitStack?.stackStatus() == StackStatus.CREATE_COMPLETE
+} finally {
+    List<Stack> toolkitStacks = Stream.of("dev", "test", "prod")
+            .map { stage -> "stacks-parameter-cdk-toolkit-" + stage }
+            .map { stackName -> Stacks.findStack(cfnClient, stackName).orElse(null) }
+            .filter { stack -> stack != null }
+            .map { stack -> ToolkitStacks.deleteToolkitStack(cfnClient, stack) }
+            .collect(Collectors.toList())
+
+    List<Stack> stacks = Stream.of("dev", "test", "prod")
+            .map { stage -> "stacks-parameter-test-stack-" + stage }
+            .map { stackName -> Stacks.findStack(cfnClient, stackName).orElse(null) }
+            .filter { stack -> stack != null }
+            .map { stack -> Stacks.deleteStack(cfnClient, stack.stackName()) }
+            .collect(Collectors.toList())
+
+    Stream.concat(toolkitStacks.stream(), stacks.stream())
+            .forEach { stack -> Stacks.awaitCompletion(cfnClient, stack) }
+}

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/BootstrapMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/BootstrapMojo.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,6 +40,12 @@ public class BootstrapMojo extends AbstractCdkMojo {
     @Parameter(defaultValue = "CDKToolkit")
     private String toolkitStackName;
 
+    /**
+     * Stacks, for which bootstrapping will be performed if it's required.
+     */
+    @Parameter
+    private Set<String> stacks;
+
     @Override
     public void execute(Path cloudAssemblyDirectory, EnvironmentResolver environmentResolver) {
         if (!Files.exists(cloudAssemblyDirectory)) {
@@ -48,6 +55,7 @@ public class BootstrapMojo extends AbstractCdkMojo {
 
         CloudDefinition cloudDefinition = CloudDefinition.create(cloudAssemblyDirectory);
         Map<String, Integer> environments = cloudDefinition.getStacks().stream()
+                .filter(stack -> this.stacks == null || this.stacks.contains(stack.getStackName()))
                 .filter(this::isBootstrapRequired)
                 .collect(Collectors.groupingBy(
                         StackDefinition::getEnvironment,

--- a/aws-cdk-maven-plugin/src/test/java/io/linguarobot/aws/cdk/maven/ToolkitStacks.java
+++ b/aws-cdk-maven-plugin/src/test/java/io/linguarobot/aws/cdk/maven/ToolkitStacks.java
@@ -1,0 +1,53 @@
+package io.linguarobot.aws.cdk.maven;
+
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.Output;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class ToolkitStacks {
+
+    private ToolkitStacks() {
+    }
+
+    public static Stack deleteToolkitStack(CloudFormationClient client, Stack stack) {
+        Stacks.findOutput(stack, "BucketName")
+                .map(Output::outputValue)
+                .ifPresent(bucketName -> cleanBucket(S3Client.create(), bucketName));
+
+        return Stacks.deleteStack(client, stack.stackName());
+    }
+
+    private static void cleanBucket(S3Client client, String bucketName) {
+        ListObjectVersionsRequest listObjectVersionsRequest = ListObjectVersionsRequest.builder()
+                .bucket(bucketName)
+                .build();
+        Iterator<ObjectVersion> objectVersionsIterator = client.listObjectVersionsPaginator(listObjectVersionsRequest)
+                .versions()
+                .iterator();
+        while (objectVersionsIterator.hasNext()) {
+            List<ObjectIdentifier> objectIdentifiers = new ArrayList<>();
+            while (objectVersionsIterator.hasNext() && objectIdentifiers.size() < 1000) {
+                ObjectVersion objectVersion = objectVersionsIterator.next();
+                objectIdentifiers.add(toObjectIdentifier(objectVersion));
+            }
+            DeleteObjectsRequest deleteRequest = DeleteObjectsRequest.builder()
+                    .bucket(bucketName)
+                    .delete(Delete.builder().objects(objectIdentifiers).build())
+                    .build();
+            client.deleteObjects(deleteRequest);
+        }
+    }
+
+    private static ObjectIdentifier toObjectIdentifier(ObjectVersion objectVersion) {
+        return ObjectIdentifier.builder()
+                .key(objectVersion.key())
+                .versionId(objectVersion.versionId())
+                .build();
+    }
+}


### PR DESCRIPTION
Add `stacks` parameter specifying which stacks need to be deployed. The parameter is used in `bootstrap` and `deploy` goals. A toolkit stack is created only for those stacks, that are to be deployed. If a stack specified in the parameter isn't defined in the CDK application, a warning is printed.