### PR TITLE
Add the possibility to pass arguments to the CDK app class

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ public class MyApp {
 | `<app>` | `String` | `0.0.1` | Full class name of the CDK app class defining the cloud infrastructure. |
 | `<profile>` | `String` | `0.0.1` | A profile that will be used to find credentials and region. |
 | `<cloudAssemblyDirectory>` | `String` | `0.0.1` | A directory where the cloud assembly will be synthesized. |
+| `<arguments>` | `List<String>` | `0.0.5` | A list of arguments to be passed to the CDK application. |
 
 ### Bootstrapping
 

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-basic/pom.xml
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-basic/pom.xml
@@ -56,6 +56,9 @@
                         <configuration>
                             <app>io.linguarobot.aws.cdk.maven.it.DeployBasicTestApp</app>
                             <toolkitStackName>basic-it-cdk-toolkit</toolkitStackName>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
                             <parameters>
                                 <Parameter>OverriddenValue</Parameter>
                             </parameters>

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-basic/src/main/java/io/linguarobot/aws/cdk/maven/it/DeployBasicTestApp.java
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-basic/src/main/java/io/linguarobot/aws/cdk/maven/it/DeployBasicTestApp.java
@@ -9,8 +9,9 @@ import software.amazon.awscdk.core.StackProps;
 public class DeployBasicTestApp {
 
     public static void main(String[] args) {
+        String stage = args.length > 0 ? args[0] : "dev";
         App app = new App();
-        new DeployBasicTestStack(app, "synth-deploy-basic-test-stack");
+        new DeployBasicTestStack(app, "synth-deploy-basic-test-stack", stage);
         app.synth();
     }
 

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-basic/src/main/java/io/linguarobot/aws/cdk/maven/it/DeployBasicTestStack.java
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-basic/src/main/java/io/linguarobot/aws/cdk/maven/it/DeployBasicTestStack.java
@@ -3,27 +3,22 @@ package io.linguarobot.aws.cdk.maven.it;
 import software.amazon.awscdk.core.*;
 import software.amazon.awscdk.services.s3.BlockPublicAccess;
 import software.amazon.awscdk.services.s3.Bucket;
-import software.amazon.awscdk.services.s3.BucketProps;
 
 
 public class DeployBasicTestStack extends Stack {
 
-    public DeployBasicTestStack(final Construct scope, final String id) {
-        this(scope, id, null);
-    }
-
-    public DeployBasicTestStack(final Construct scope, final String id, final StackProps props) {
-        super(scope, id, props);
+    public DeployBasicTestStack(final Construct scope, final String id, String stage) {
+        super(scope, id);
 
         CfnParameter parameter = CfnParameter.Builder.create(this, "Parameter")
                 .defaultValue("DefaultValue")
                 .build();
 
-        BucketProps bucketProperties = BucketProps.builder()
+        Bucket bucket = Bucket.Builder.create(this, "Bucket")
+                .removalPolicy(RemovalPolicy.DESTROY)
+                .bucketName(String.join("-", id, "data", stage))
                 .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
                 .build();
-
-        Bucket bucket = new Bucket(this, "bucket", bucketProperties);
 
         CfnOutput.Builder.create(this, "BucketName")
                 .description("The name of the bucket")
@@ -32,6 +27,10 @@ public class DeployBasicTestStack extends Stack {
 
         CfnOutput.Builder.create(this, "ParameterValue")
                 .value(parameter.getValueAsString())
+                .build();
+
+        CfnOutput.Builder.create(this, "Stage")
+                .value(stage)
                 .build();
     }
 }

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-basic/verify.groovy
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-basic/verify.groovy
@@ -1,8 +1,6 @@
 import io.linguarobot.aws.cdk.maven.Stacks
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
-import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
 
 CloudFormationClient cfnClient = CloudFormationClient.create();
 
@@ -23,26 +21,18 @@ try {
     assert stack?.stackStatus() == StackStatus.CREATE_COMPLETE
 
     def parameterValue = Stacks.findOutput(stack, "ParameterValue")
-            .map{output -> output.outputValue()}
+            .map { output -> output.outputValue() }
             .orElse(null)
     assert parameterValue == "OverriddenValue"
+
+    def stage = Stacks.findOutput(stack, "Stage")
+            .map {output -> output.outputValue() }
+            .orElse(null)
+    assert stage == "test"
 
     def toolkitStack = Stacks.findStack(cfnClient, "basic-cdk-toolkit").orElse(null);
     assert toolkitStack == null
 } finally {
-    def stack = Stacks.findStack(cfnClient, "synth-deploy-basic-test-stack").orElse(null)
-    if (stack != null) {
-        Stacks.findOutput(stack, "BucketName")
-                .map { output -> output.outputValue() }
-                .ifPresent { bucketName ->
-                    {
-                        def s3Client = S3Client.create()
-                        def deleteBucketRequest = DeleteBucketRequest.builder()
-                                .bucket(bucketName)
-                                .build()
-                        s3Client.deleteBucket(deleteBucketRequest)
-                    }
-                }
-        Stacks.awaitCompletion(cfnClient, Stacks.deleteStack(cfnClient, stack.stackName()))
-    }
+    Stacks.findStack(cfnClient, "synth-deploy-basic-test-stack")
+            .ifPresent{stack -> Stacks.awaitCompletion(cfnClient, Stacks.deleteStack(cfnClient, stack.stackName()))}
 }


### PR DESCRIPTION
Adds the possibility to pass arguments (by specifying them in `<arguments>` parameter of `synth` goal) to `main` method of the CDK application:

```xml
<plugin>
    <groupId>io.linguarobot</groupId>
    <artifactId>aws-cdk-maven-plugin</artifactId>
    <version>${aws.cdk.plugin.version}</version>
    <executions>
        <execution>
            <id>deploy-cdk-app</id>
            <goals>
                <goal>synth</goal>
                <goal>deploy</goal>
            </goals>
            <configuration>
                <app>io.linguarobot.aws.cdk.App</app>
                <arguments>
                    <argument>${stage}</argument>
                </arguments>
            </configuration>
        </execution>
    </executions>
</plugin>
```
The argument can be used later in the `App#main` method:
```
public static void main(String[] args) {
    String stage = args.length > 0 ? args[0] : "dev";
    ...
}
```