### PR TITLE
The deployment should fail if stack status is ROLLBACK_COMPLETE

### DIFF
--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/Stacks.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/Stacks.java
@@ -118,7 +118,7 @@ public class Stacks {
     }
 
     public static boolean isRolledBack(Stack stack) {
-        return stack.stackStatus().toString().endsWith("_ROLLBACK_COMPLETE");
+        return stack.stackStatus() == StackStatus.ROLLBACK_COMPLETE || stack.stackStatus().toString().endsWith("_ROLLBACK_COMPLETE");
     }
 
     public static Stack awaitCompletion(CloudFormationClient client, Stack stack) {


### PR DESCRIPTION
After the previous change to the way stack state is determined, the deployment is considered successful in case the stack status is `ROLLBACK_COMPLETE`. The pull request fixes it.