### PR TITLE
Do not use the same table name in the integration tests

### DIFF
--- a/aws-cdk-maven-plugin/src/it/synth-deploy-after-rollback/invalid-template.json
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-after-rollback/invalid-template.json
@@ -6,7 +6,7 @@
       "Type": "AWS::DynamoDB::Table",
       "DeletionPolicy": "Delete",
       "Properties": {
-        "TableName": "user",
+        "TableName": "deploy_after_rollback_it_user",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-after-rollback/src/main/java/io/linguarobot/aws/cdk/maven/it/DeployAfterRollbackTestStack.java
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-after-rollback/src/main/java/io/linguarobot/aws/cdk/maven/it/DeployAfterRollbackTestStack.java
@@ -16,7 +16,7 @@ public class DeployAfterRollbackTestStack extends Stack {
 
         Table.Builder.create(this, "UserTable")
                 .removalPolicy(RemovalPolicy.DESTROY)
-                .tableName("user")
+                .tableName("deploy_after_rollback_it_user")
                 .billingMode(BillingMode.PAY_PER_REQUEST)
                 .partitionKey(Attribute.builder()
                         .name("id")

--- a/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/pom.xml
+++ b/aws-cdk-maven-plugin/src/it/synth-deploy-stacks-parameter/pom.xml
@@ -71,7 +71,7 @@
                             </stacks>
                             <toolkitStackName>stacks-parameter-cdk-toolkit-dev</toolkitStackName>
                             <parameters>
-                                <UserTableName>user_dev</UserTableName>
+                                <UserTableName>stacks_parameter_it_user_dev</UserTableName>
                             </parameters>
                         </configuration>
                     </execution>
@@ -87,7 +87,7 @@
                             </stacks>
                             <toolkitStackName>stacks-parameter-cdk-toolkit-prod</toolkitStackName>
                             <parameters>
-                                <UserTableName>user</UserTableName>
+                                <UserTableName>stacks_parameter_it_user</UserTableName>
                             </parameters>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### Description

Currently, both 'synth-deploy-after-rollback' and `synth-deploy-stacks-parameter` integration tests define a table with the same name (`user`). This causes a problem if the tests are run in parallel. The PR fixes the issue by renaming the tables.