### PR TITLE
Do not print stack resource events in batch mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,5 @@ jobs:
           path: '~/.m2'
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: 'Run mvn package'
-        run: 'mvn -B clean package --file ./pom.xml -DskipTests=false'
+      - name: 'Run mvn verify'
+        run: 'mvn --no-transfer-progress --batch-mode clean verify -DskipUTs=false -DskipITs=true'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           maven-version: 3.5.0
       - name: 'Run integration tests'
-        run: 'mvn -B clean verify --file ./pom.xml -DskipTests=true -DskipITs=false -D"invoker.test"=${{ matrix.test }}'
+        run: 'mvn --no-transfer-progress --batch-mode clean verify -DskipUTs=true -DskipITs=false -D"invoker.test"=${{ matrix.test }}'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
             --no-transfer-progress \
             --batch-mode \
             -Prelease \
-            -DskipTests=true \
+            -DskipUTs=true \
             -DskipITs=true \
             -Dgpg.keyname=${{ secrets.OSSRH_GPG_SECRET_KEY_ID }} \
             -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/BootstrapMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/BootstrapMojo.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
@@ -32,6 +33,9 @@ public class BootstrapMojo extends AbstractCloudActionMojo {
     private static final int MAX_TOOLKIT_STACK_VERSION = 1;
     private static final int DEFAULT_BOOTSTRAP_STACK_VERSION = getDefaultBootstrapStackVersion();
     private static final String BOOTSTRAP_VERSION_OUTPUT = "BootstrapVersion";
+
+    @Parameter(defaultValue = "${settings}", required = true, readonly = true)
+    private Settings settings;
 
     /**
      * The name of the CDK toolkit stack.
@@ -200,7 +204,7 @@ public class BootstrapMojo extends AbstractCloudActionMojo {
 
     private Stack awaitCompletion(CloudFormationClient client, Stack stack) {
         Stack completedStack;
-        if (logger.isInfoEnabled()) {
+        if (logger.isInfoEnabled() && settings.isInteractiveMode()) {
             completedStack = Stacks.awaitCompletion(client, stack, new LoggingStackEventListener());
         } else {
             completedStack = Stacks.awaitCompletion(client, stack);

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DeployMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DeployMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +26,9 @@ public class DeployMojo extends AbstractCloudActionMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${settings}", required = true, readonly = true)
+    protected Settings settings;
 
     /**
      * The name of the CDK toolkit stack
@@ -68,7 +72,7 @@ public class DeployMojo extends AbstractCloudActionMojo {
                     FileAssetPublisher filePublisher = new FileAssetPublisher(resolvedEnvironment);
                     ToolkitConfiguration toolkitConfiguration = new ToolkitConfiguration(toolkitStackName);
                     return new StackDeployer(cloudDefinition.getCloudAssemblyDirectory(), resolvedEnvironment,
-                            toolkitConfiguration, filePublisher, dockerImagePublisher);
+                            toolkitConfiguration, filePublisher, dockerImagePublisher, settings);
                 });
 
                 if (!stack.getResources().isEmpty()) {

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DestroyMojo.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DestroyMojo.java
@@ -2,6 +2,7 @@ package io.linguarobot.aws.cdk.maven;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -19,6 +20,9 @@ import java.util.stream.IntStream;
 public class DestroyMojo extends AbstractCloudActionMojo {
 
     private static final Logger logger = LoggerFactory.getLogger(DestroyMojo.class);
+
+    @Parameter(defaultValue = "${settings}", required = true, readonly = true)
+    private Settings settings;
 
     /**
      * Stacks to be destroyed. By default, all the stacks defined in the cloud application will be deleted.
@@ -62,8 +66,8 @@ public class DestroyMojo extends AbstractCloudActionMojo {
                 .orElse(null);
         if (stack != null) {
             stack = Stacks.deleteStack(client, stack.stackName());
-            if (logger.isInfoEnabled()) {
-                logger.info("The stack '{}' is being deleted, waiting until the operation is completed", stack.stackName());
+            logger.info("The stack '{}' is being deleted, waiting until the operation is completed", stack.stackName());
+            if (logger.isInfoEnabled() && settings.isInteractiveMode()) {
                 stack = Stacks.awaitCompletion(client, stack, new LoggingStackEventListener());
             } else {
                 stack = Stacks.awaitCompletion(client, stack);

--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/StackDeployer.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/StackDeployer.java
@@ -7,6 +7,7 @@ import io.linguarobot.aws.cdk.ContainerAssetData;
 import io.linguarobot.aws.cdk.ContainerImageAssetMetadata;
 import io.linguarobot.aws.cdk.FileAssetData;
 import io.linguarobot.aws.cdk.FileAssetMetadata;
+import org.apache.maven.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -52,17 +53,20 @@ public class StackDeployer {
     private final ToolkitConfiguration toolkitConfiguration;
     private final FileAssetPublisher fileAssetPublisher;
     private final DockerImageAssetPublisher dockerImagePublisher;
+    private final Settings settings;
 
     public StackDeployer(Path cloudAssemblyDirectory,
                          ResolvedEnvironment environment,
                          ToolkitConfiguration toolkitConfiguration,
                          FileAssetPublisher fileAssetPublisher,
-                         DockerImageAssetPublisher dockerImagePublisher) {
+                         DockerImageAssetPublisher dockerImagePublisher,
+                         Settings settings) {
         this.cloudAssemblyDirectory = cloudAssemblyDirectory;
         this.environment = environment;
         this.toolkitConfiguration = toolkitConfiguration;
         this.fileAssetPublisher = fileAssetPublisher;
         this.dockerImagePublisher = dockerImagePublisher;
+        this.settings = settings;
         this.client = CloudFormationClient.builder()
                 .region(environment.getRegion())
                 .credentialsProvider(StaticCredentialsProvider.create(environment.getCredentials()))
@@ -424,7 +428,7 @@ public class StackDeployer {
 
     private Stack awaitCompletion(Stack stack) {
         Stack completedStack;
-        if (logger.isInfoEnabled()) {
+        if (logger.isInfoEnabled() && settings.isInteractiveMode()) {
             completedStack = Stacks.awaitCompletion(client, stack, new LoggingStackEventListener());
         } else {
             completedStack = Stacks.awaitCompletion(client, stack);


### PR DESCRIPTION
By default, each time a stack is created/updated or deleted, the resource events are printed in the console in the form of a table to indicate the progress. The pull respect adds support for Maven batch mode (`-B` flag). In case Maven is in batch mode, the table with resource events is omitted.