### PR TITLE
Fix the path to the Dockerfile passed while building an image

### DIFF
--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DockerImageAssetPublisher.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/DockerImageAssetPublisher.java
@@ -89,13 +89,6 @@ public class DockerImageAssetPublisher {
         }
     }
 
-    private void login() {
-        AuthorizationData authorizationData = getAuthorizationData()
-                .orElseThrow(() -> new CdkPluginException("Unable to retrieve authorization token from ECR"));
-
-        processRunner.run(toDockerLoginCommand(authorizationData));
-    }
-
     private List<String> toBuildCommand(ImageBuild build) {
         List<String> buildCommand = new ArrayList<>();
         buildCommand.add("docker");
@@ -111,10 +104,8 @@ public class DockerImageAssetPublisher {
             buildCommand.add("--target");
             buildCommand.add(build.getTarget());
         }
-        if (build.getDockerfile() != null) {
-            buildCommand.add("--file");
-            buildCommand.add(build.getContextDirectory().relativize(build.getDockerfile()).toString());
-        }
+        buildCommand.add("--file");
+        buildCommand.add(build.getDockerfile().toString());
         buildCommand.add(build.getContextDirectory().toString());
 
         return buildCommand;


### PR DESCRIPTION
### Description

The Dockerfile path passed to Docker by the plugin to build an image is relative to the context path, which is incorrect as Docker expects absolute/relative to the working directory path. The PR fixes this issue (#60).