### PR TITLE
Propagate environment variables to the Docker process

### DIFF
--- a/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/process/ProcessContext.java
+++ b/aws-cdk-maven-plugin/src/main/java/io/linguarobot/aws/cdk/maven/process/ProcessContext.java
@@ -48,7 +48,6 @@ public class ProcessContext {
         private OutputStream output;
 
         private Builder() {
-            this.environment = ImmutableMap.of();
             this.output = System.out;
         }
 


### PR DESCRIPTION
### Description

Environment variables are not propagated to the Docker process since `ProcessContext#getEnvironment` returns an empty `Map` by default. This causes `org.apache.commons.exec.Executor` to not use parent process environment variables (it will use them if the `environment` is not specified or if it's `null`).